### PR TITLE
docs: add free postgres setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Run command on specific app with options.
 
 Example : `npm run seqeulize --workspace=api -- --db:migrate`
 
+# Database Setup
+
+The backend uses PostgreSQL via Prisma. You can provision a free database using services such as [Neon](https://neon.tech) or [Supabase](https://supabase.com).
+
+### Using Neon (free tier)
+1. Create a Neon project and database.
+2. Copy the connection string.
+3. Duplicate `apps/api/.env.example` as `apps/api/.env` and fill in `POSTGRES_PRISMA_URL` and `POSTGRES_URL_NON_POOLING` with the connection string.
+4. Apply migrations:
+   ```bash
+   npm run migrate --workspace=api
+   ```
+5. Start the development server:
+   ```bash
+   npm run dev --workspace=api
+   ```
+
 # Rules
 
 ## Commit & Pull Request

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,11 @@
+API_PORT=8000
+# Prisma needs connection strings for Postgres
+POSTGRES_PRISMA_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?sslmode=require"
+POSTGRES_URL_NON_POOLING="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?sslmode=require"
+
+# Optional API key for client requests
+API_KEY=""
+
+# Nodemailer configuration for email features
+NODEMAILER_EMAIL=""
+NODEMAILER_PASS=""


### PR DESCRIPTION
## Summary
- document free Postgres setup using Neon
- add .env.example with required variables for API

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df22b55d88325a0261178b8956fec